### PR TITLE
add OPENAI_API_BASE url support

### DIFF
--- a/include/openai/openai.hpp
+++ b/include/openai/openai.hpp
@@ -369,14 +369,25 @@ private:
 // OpenAI
 class OpenAI {
 public:
-    OpenAI(const std::string& token = "", const std::string& organization = "", bool throw_exception = true) 
+    OpenAI(const std::string& token = "", const std::string& organization = "", bool throw_exception = true, const std::string& api_base_url = "") 
         : session_{throw_exception}, token_{token}, organization_{organization}, throw_exception_{throw_exception} {
             if (token.empty()) {
                 if(const char* env_p = std::getenv("OPENAI_API_KEY")) {
                     token_ = std::string{env_p};
                 }
             }
-            session_.setUrl("https://api.openai.com/v1/");
+            if (api_base_url.empty()) {
+                if(const char* env_p = std::getenv("OPENAI_API_BASE")) {
+                    base_url = std::string{env_p} + "/";
+                }
+                else {
+                    base_url = "https://api.openai.com/v1/";
+                }
+            }
+            else {
+                base_url = api_base_url;
+            }
+            session_.setUrl(base_url);
             session_.setToken(token_, organization_);
         }
     
@@ -470,7 +481,7 @@ public:
     }
 
 private:
-    std::string base_url{ "https://api.openai.com/v1/" };
+    std::string base_url;
 
     void setParameters(const std::string& suffix, const std::string& data, const std::string& contentType = "") {
         auto complete_url =  base_url+ suffix;


### PR DESCRIPTION
This adds support for the OPENAI_API_BASE environment variable, a standard way to redirect the other openai clients (openai-python & openai-node). It enables support of alternate openai compatible implementations, like https://github.com/oobabooga/text-generation-webui

I compiled and ran the tests against  text-generation-webui and for the working portions it was successful (it's not a complete re-implementation).