### PR TITLE
'getenv' considered in MSVC as unsafe function

### DIFF
--- a/include/openai/openai.hpp
+++ b/include/openai/openai.hpp
@@ -376,6 +376,7 @@ public:
                 if(_dupenv_s(&env_p, NULL, "OPENAI_API_KEY") == 0 && env_p != NULL) {
                     token_ = std::string{env_p};
                 }
+                free(env_p);
             }
             if (api_base_url.empty()) {
                 char* env_p;
@@ -385,6 +386,7 @@ public:
                 else {
                     base_url = "https://api.openai.com/v1/";
                 }
+                free(env_p);
             }
             else {
                 base_url = api_base_url;

--- a/include/openai/openai.hpp
+++ b/include/openai/openai.hpp
@@ -374,14 +374,14 @@ public:
             if (token.empty()) {
                 char* env_p;
                 size_t len;
-                if(_dupenv_s(&env_p, &len, "OPENAI_API_KEY") == 0) {
+                if(_dupenv_s(&env_p, &len, "OPENAI_API_KEY") == 0 && env_p != NULL) {
                     token_ = std::string{env_p};
                 }
             }
             if (api_base_url.empty()) {
                 char* env_p;
                 size_t len;
-                if(_dupenv_s(&env_p, &len, "OPENAI_API_BASE") == 0) {
+                if(_dupenv_s(&env_p, &len, "OPENAI_API_BASE") == 0 && env_p != NULL) {
                     base_url = std::string{env_p} + "/";
                 }
                 else {

--- a/include/openai/openai.hpp
+++ b/include/openai/openai.hpp
@@ -372,12 +372,16 @@ public:
     OpenAI(const std::string& token = "", const std::string& organization = "", bool throw_exception = true, const std::string& api_base_url = "") 
         : session_{throw_exception}, token_{token}, organization_{organization}, throw_exception_{throw_exception} {
             if (token.empty()) {
-                if(const char* env_p = std::getenv("OPENAI_API_KEY")) {
+                char* env_p;
+                size_t len;
+                if(_dupenv_s(&env_p, &len, "OPENAI_API_KEY") == 0) {
                     token_ = std::string{env_p};
                 }
             }
             if (api_base_url.empty()) {
-                if(const char* env_p = std::getenv("OPENAI_API_BASE")) {
+                char* env_p;
+                size_t len;
+                if(_dupenv_s(&env_p, &len, "OPENAI_API_BASE") == 0) {
                     base_url = std::string{env_p} + "/";
                 }
                 else {

--- a/include/openai/openai.hpp
+++ b/include/openai/openai.hpp
@@ -373,15 +373,13 @@ public:
         : session_{throw_exception}, token_{token}, organization_{organization}, throw_exception_{throw_exception} {
             if (token.empty()) {
                 char* env_p;
-                size_t len;
-                if(_dupenv_s(&env_p, &len, "OPENAI_API_KEY") == 0 && env_p != NULL) {
+                if(_dupenv_s(&env_p, NULL, "OPENAI_API_KEY") == 0 && env_p != NULL) {
                     token_ = std::string{env_p};
                 }
             }
             if (api_base_url.empty()) {
                 char* env_p;
-                size_t len;
-                if(_dupenv_s(&env_p, &len, "OPENAI_API_BASE") == 0 && env_p != NULL) {
+                if(_dupenv_s(&env_p, NULL, "OPENAI_API_BASE") == 0 && env_p != NULL) {
                     base_url = std::string{env_p} + "/";
                 }
                 else {


### PR DESCRIPTION
The function "std::getenv()" is flagged as insecure in Visual Studio ([why](https://stackoverflow.com/questions/48568707/getenv-function-may-be-unsafe-really)) , in order to fix this, I changed the functions to "_dupenv_s()" instead.

The code is still the same as before, just with a more secure function. 

I tested the changes with one of the example programs, works exactly as before.