### PR TITLE
fix: memory leak in makeRequest due to un-freed curl_slist

### DIFF
--- a/include/openai/openai.hpp
+++ b/include/openai/openai.hpp
@@ -441,7 +441,7 @@ public:
             }
             if (api_base_url.empty()) {
                 if(const char* env_p = std::getenv("OPENAI_API_BASE")) {
-                    base_url = std::string{env_p} + "/";
+                    base_url = std::string{env_p};
                 }
                 else {
                     base_url = "https://api.openai.com/v1/";
@@ -449,6 +449,9 @@ public:
             }
             else {
                 base_url = api_base_url;
+            }
+            if (not base_url.empty() and base_url.back() != '/') {
+                base_url += '/';
             }
             session_.setUrl(base_url);
             session_.setToken(token_, organization_);

--- a/include/openai/openai.hpp
+++ b/include/openai/openai.hpp
@@ -218,6 +218,9 @@ inline Response Session::makeRequest(const std::string& contentType) {
 
     res_ = curl_easy_perform(curl_);
 
+    /* free the list of headers */
+    curl_slist_free_all(headers);
+
     bool is_error = false;
     std::string error_msg{};
     if(res_ != CURLE_OK) {


### PR DESCRIPTION
The curl_slist used for setting HTTP headers was being allocated with curl_slist_append but was never deallocated. This resulted in a memory leak for every request made, as reported in issue #30.

I have added a call to curl_slist_free_all(headers) after the curl_easy_perform call.
